### PR TITLE
Add breadcrumbs log level

### DIFF
--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -87,7 +87,8 @@ module Sentry
       config.detect_release
       apply_patches(config)
       client = Client.new(config)
-      scope = Scope.new(max_breadcrumbs: config.max_breadcrumbs)
+      scope = Scope.new(max_breadcrumbs: config.max_breadcrumbs,
+                        breadcrumbs_log_level: config.breadcrumbs_log_level)
       hub = Hub.new(client, scope)
       Thread.current.thread_variable_set(THREAD_LOCAL, hub)
       @main_hub = hub

--- a/sentry-ruby/lib/sentry/breadcrumb_buffer.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb_buffer.rb
@@ -3,15 +3,21 @@ require "sentry/breadcrumb"
 module Sentry
   class BreadcrumbBuffer
     DEFAULT_SIZE = 100
+    DEFAULT_LOG_LEVEL = :debug
+    LEVELS = %w[debug info warn error fatal].freeze
+
     include Enumerable
 
     attr_accessor :buffer
 
-    def initialize(size = nil)
+    def initialize(size = nil, log_level = nil)
       @buffer = Array.new(size || DEFAULT_SIZE)
+      @log_level_index = LEVELS.find_index((log_level || DEFAULT_LOG_LEVEL).to_s.downcase)
     end
 
     def record(crumb)
+      return if !crumb.level.nil? && LEVELS.find_index(crumb.level.to_s.downcase) < @log_level_index
+
       yield(crumb) if block_given?
       @buffer.slice!(0)
       @buffer << crumb

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -66,6 +66,9 @@ module Sentry
     # Max number of breadcrumbs a breadcrumb buffer can hold
     attr_accessor :max_breadcrumbs
 
+    # The log level of breadcrumbs that a breadcrumb buffer can hold
+    attr_accessor :breadcrumbs_log_level
+
     # Number of lines of code context to capture, or nil for none
     attr_accessor :context_lines
 
@@ -186,6 +189,7 @@ module Sentry
       self.debug = false
       self.background_worker_threads = Concurrent.processor_count
       self.max_breadcrumbs = BreadcrumbBuffer::DEFAULT_SIZE
+      self.breadcrumbs_log_level = BreadcrumbBuffer::DEFAULT_LOG_LEVEL
       self.breadcrumbs_logger = []
       self.context_lines = 3
       self.environment = environment_from_env

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -9,8 +9,9 @@ module Sentry
 
     attr_reader(*ATTRIBUTES)
 
-    def initialize(max_breadcrumbs: nil)
+    def initialize(max_breadcrumbs: nil, breadcrumbs_log_level: nil)
       @max_breadcrumbs = max_breadcrumbs
+      @breadcrumbs_log_level = breadcrumbs_log_level
       set_default_value
     end
 
@@ -186,7 +187,7 @@ module Sentry
     end
 
     def set_new_breadcrumb_buffer
-      @breadcrumbs = BreadcrumbBuffer.new(@max_breadcrumbs)
+      @breadcrumbs = BreadcrumbBuffer.new(@max_breadcrumbs, @breadcrumbs_log_level)
     end
 
 


### PR DESCRIPTION
This allows filtering logs that a breadcrumb buffer can hold.

Signed-off-by: Kostiantyn Kostiuk <konstantin@daynix.com>

Thanks for your Pull Request 🎉 

**Please keep these instructions in mind so we can review it more efficiently:**

- Add the references of all the related issues/PRs in the description
- Whether it's a new feature or a bug fix, make sure they're covered by new test cases
- If this PR contains any refactoring work, please give it its own commit(s)
- Finally, please add an entry to the corresponding changelog


**Other Notes**
- We squash all commits before merging
- We generally review new PRs within a week
- If you have any question, you can ask for feedback in our [discord community](https://discord.gg/Ww9hbqr) first

## Description
Add breadcrumbs log level. This allows filtering logs that a breadcrumb buffer can hold.