### PR TITLE
Allow configuring breadcrumbs log level

### DIFF
--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -87,7 +87,8 @@ module Sentry
       config.detect_release
       apply_patches(config)
       client = Client.new(config)
-      scope = Scope.new(max_breadcrumbs: config.max_breadcrumbs)
+      scope = Scope.new(max_breadcrumbs: config.max_breadcrumbs,
+                        breadcrumbs_log_level: config.breadcrumbs_log_level)
       hub = Hub.new(client, scope)
       Thread.current.thread_variable_set(THREAD_LOCAL, hub)
       @main_hub = hub

--- a/sentry-ruby/lib/sentry/breadcrumb_buffer.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb_buffer.rb
@@ -3,15 +3,21 @@ require "sentry/breadcrumb"
 module Sentry
   class BreadcrumbBuffer
     DEFAULT_SIZE = 100
+    DEFAULT_LOG_LEVEL = :debug
+    LEVELS = %w[debug info warn error fatal].freeze
+
     include Enumerable
 
     attr_accessor :buffer
 
-    def initialize(size = nil)
+    def initialize(size = nil, log_level = nil)
       @buffer = Array.new(size || DEFAULT_SIZE)
+      @log_level_index = LEVELS.find_index((log_level || DEFAULT_LOG_LEVEL).to_s.downcase)
     end
 
     def record(crumb)
+      return if !crumb.level.nil? && LEVELS.find_index(crumb.level.to_s.downcase) < @log_level_index
+
       yield(crumb) if block_given?
       @buffer.slice!(0)
       @buffer << crumb

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -66,6 +66,9 @@ module Sentry
     # Max number of breadcrumbs a breadcrumb buffer can hold
     attr_accessor :max_breadcrumbs
 
+    # The log level of breadcrumbs that a breadcrumb buffer can hold
+    attr_accessor :breadcrumbs_log_level
+
     # Number of lines of code context to capture, or nil for none
     attr_accessor :context_lines
 
@@ -186,6 +189,7 @@ module Sentry
       self.debug = false
       self.background_worker_threads = Concurrent.processor_count
       self.max_breadcrumbs = BreadcrumbBuffer::DEFAULT_SIZE
+      self.breadcrumbs_log_level = BreadcrumbBuffer::DEFAULT_LOG_LEVEL
       self.breadcrumbs_logger = []
       self.context_lines = 3
       self.environment = environment_from_env

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -9,8 +9,9 @@ module Sentry
 
     attr_reader(*ATTRIBUTES)
 
-    def initialize(max_breadcrumbs: nil)
+    def initialize(max_breadcrumbs: nil, breadcrumbs_log_level: nil)
       @max_breadcrumbs = max_breadcrumbs
+      @breadcrumbs_log_level = breadcrumbs_log_level
       set_default_value
     end
 
@@ -186,7 +187,7 @@ module Sentry
     end
 
     def set_new_breadcrumb_buffer
-      @breadcrumbs = BreadcrumbBuffer.new(@max_breadcrumbs)
+      @breadcrumbs = BreadcrumbBuffer.new(@max_breadcrumbs, @breadcrumbs_log_level)
     end
 
 

--- a/sentry-ruby/spec/sentry/breadcrumb_buffer_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb_buffer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Sentry::BreadcrumbBuffer do
 
   describe "#record" do
     subject do
-      described_class.new(1)
+      described_class.new(1, :warn)
     end
 
     it "doesn't exceed the size limit" do
@@ -52,6 +52,36 @@ RSpec.describe Sentry::BreadcrumbBuffer do
       expect(subject.buffer.size).to eq(1)
 
       expect(subject.peek).to eq(crumb_2)
+    end
+
+    it "records crumb without level" do
+      subject.record(crumb_1)
+
+      expect(subject.peek).to eq(crumb_1)
+    end
+
+    it "records crumb with the level equal to the log_level" do
+      crumb_1.level = :warn
+
+      subject.record(crumb_1)
+
+      expect(subject.peek).to eq(crumb_1)
+    end
+
+    it "records crumb with the level greater than the log_level" do
+      crumb_1.level = :error
+
+      subject.record(crumb_1)
+
+      expect(subject.peek).to eq(crumb_1)
+    end
+
+    it "skips crumb with the level lower than the log_level" do
+      crumb_1.level = :debug
+
+      subject.record(crumb_1)
+
+      expect(subject.peek).to be_nil
     end
   end
 

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe Sentry::Scope do
       scope = described_class.new(max_breadcrumbs: 10)
       expect(scope.breadcrumbs.buffer.count).to eq(10)
     end
+
+    it "allows setting breadcrumb buffer's log level" do
+      scope = described_class.new(breadcrumbs_log_level: :warn)
+      expect(scope.breadcrumbs.instance_variable_get(:@log_level_index)).to eq(2)
+    end
   end
 
   describe "#dup" do

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe Sentry do
       current_scope = described_class.get_current_scope
       expect(current_scope.breadcrumbs.buffer.size).to eq(1)
     end
+
+    it "initializes Scope with correct breadcrumbs_log_level" do
+      described_class.init do |config|
+        config.breadcrumbs_log_level = :info
+      end
+
+      current_scope = described_class.get_current_scope
+      expect(current_scope.breadcrumbs.instance_variable_get(:@log_level_index)).to eq(1)
+    end
   end
 
   describe "#clone_hub_to_current_thread" do


### PR DESCRIPTION
This allows filtering logs that a breadcrumb buffer can hold.

Signed-off-by: Kostiantyn Kostiuk <konstantin@daynix.com>

Thanks for your Pull Request 🎉 

**Please keep these instructions in mind so we can review it more efficiently:**

- Add the references of all the related issues/PRs in the description
- Whether it's a new feature or a bug fix, make sure they're covered by new test cases
- If this PR contains any refactoring work, please give it its own commit(s)
- Finally, please add an entry to the corresponding changelog


**Other Notes**
- We squash all commits before merging
- We generally review new PRs within a week
- If you have any question, you can ask for feedback in our [discord community](https://discord.gg/Ww9hbqr) first

## Description
Describe your changes:
